### PR TITLE
Adds server preferences

### DIFF
--- a/stabby/bot.py
+++ b/stabby/bot.py
@@ -315,7 +315,7 @@ async def regen(
 @default_ratelimiter
 async def set_server_preferences(
         interaction: discord.Interaction,
-        required_negative_prompt: OPtional[str] = None,
+        required_negative_prompt: Optional[str] = None,
         default_negative_prompt: Optional[str] = None,
 ):
     """Function"""
@@ -324,9 +324,10 @@ async def set_server_preferences(
         return
     settings = {
         'required_negative_prompt': required_negative_prompt,
-        'default_negative_propt': default_negative_prompt,
+        'default_negative_prompt': default_negative_prompt,
     }
-    for key in settings.keys():
+    settings_keys = list(settings.items())
+    for key, value in settings_keys:
         if settings[key] is None:
             settings.pop(key, None)
     
@@ -334,7 +335,7 @@ async def set_server_preferences(
         saved_server_prefs = session.scalar(select(ServerPreferences).where(ServerPreferences.server_id == interaction.guild_id))
         if saved_server_prefs is None:
             saved_server_prefs = ServerPreferences(server_id=interaction.guild_id)
-            session.add(saved_preferences)
+            session.add(saved_server_prefs)
 
         saved_server_prefs.update_from_dict(settings)
         session.commit()
@@ -363,9 +364,10 @@ async def unset_server_preferences(
         else:
             settings = {
                 'required_negative_prompt': required_negative_prompt,
-                'default_negative_propt': default_negative_prompt,
+                'default_negative_prompt': default_negative_prompt,
             }
-            for key in settings.keys():
+            settings_keys = list(settings.items())
+            for key, value in settings_keys:
                 if settings[key]:
                     settings[key] = None
                 else:

--- a/stabby/bot.py
+++ b/stabby/bot.py
@@ -10,7 +10,7 @@ from discord import File, app_commands
 from functools import wraps, partial
 
 from stabby import conf, generation, grammar
-from stabby.schema import db_session, Preferences, Generation
+from stabby.schema import db_session, Preferences, Generation, ServerPreferences
 from sqlalchemy import select
 
 
@@ -217,6 +217,12 @@ async def generate(
         restore_faces: bool = True
     ):
     """Generates an image"""
+    with db_session() as session:
+        saved_server_prefs = session.scalar(select(ServerPreferences).where(ServerPreferences.server_id == interaction.guild_id))
+        if negative_prompt is None:
+            negative_prompt = saved_server_prefs.default_negative_prompt
+        if saved_server_prefs.required_negative_prompt:
+            negative_prompt = F"{negative_prompt}, {saved_server_prefs.required_negative_prompt}"
     await generation_interaction(
         interaction,
         prompt=prompt,
@@ -296,6 +302,79 @@ async def regen(
         **regen_params
     )
 
+
+@client.tree.command()
+@app_commands.describe(
+    default_negative_prompt="A negative prompt to apply if none is provided",
+    required_negative_prompt="A negative prompt to append to all prompts",
+)
+@app_commands.autocomplete(
+    default_negative_prompt=make_autocompleter('default_negative_prompt'),
+    required_negative_prompt=make_autocompleter('required_negative_prompt'),
+)
+@default_ratelimiter
+async def set_server_preferences(
+        interaction: discord.Interaction,
+        required_negative_prompt: OPtional[str] = None,
+        default_negative_prompt: Optional[str] = None,
+):
+    """Function"""
+    if interaction.guild.owner_id != interaction.user.id:
+        await interaction.followup.send("No")
+        return
+    settings = {
+        'required_negative_prompt': required_negative_prompt,
+        'default_negative_propt': default_negative_prompt,
+    }
+    for key in settings.keys():
+        if settings[key] is None:
+            settings.pop(key, None)
+    
+    with db_session() as session:
+        saved_server_prefs = session.scalar(select(ServerPreferences).where(ServerPreferences.server_id == interaction.guild_id))
+        if saved_server_prefs is None:
+            saved_server_prefs = ServerPreferences(server_id=interaction.guild_id)
+            session.add(saved_preferences)
+
+        saved_server_prefs.update_from_dict(settings)
+        session.commit()
+
+    await interaction.followup.send(F"Server preferences saved as: {saved_server_prefs.as_dict()}")
+
+@client.tree.command()
+@app_commands.describe(
+    default_negative_prompt="A negative prompt to apply if none is provided",
+    required_negative_prompt="A negative prompt to append to all prompts",
+)
+@default_ratelimiter
+async def unset_server_preferences(
+        interaction: discord.Interaction,
+        default_negative_prompt: Optional[bool] = None,
+        required_negative_prompt: Optional[bool] = None,
+) -> None:
+    if interaction.guild.owner_id != interaction.user.id:
+        await interaction.followup.send("No")
+        return
+    with db_session() as session:
+        saved_server_prefs = session.scalar(select(ServerPreferences).where(ServerPreferences.server_id == interaction.guild_id))
+        if saved_server_prefs is None:
+            saved_preferences = ServerPreferences(server_id=interaction.guild_id)
+            session.add(saved_server_prefs)
+        else:
+            settings = {
+                'required_negative_prompt': required_negative_prompt,
+                'default_negative_propt': default_negative_prompt,
+            }
+            for key in settings.keys():
+                if settings[key]:
+                    settings[key] = None
+                else:
+                    settings.pop(key, None)
+            saved_server_prefs.update_from_dict(settings)
+        
+        session.commit()
+    await interaction.followup.send(F"Server preferences saved as: {saved_server_prefs.as_dict()}")
+    
 
 @client.tree.command()
 @app_commands.describe()

--- a/stabby/schema.py
+++ b/stabby/schema.py
@@ -66,6 +66,30 @@ class Preferences(Base):
             
             return saved_preferences
 
+class ServerPreferences(Base):
+    __tablename__ = "server_preferences"
+    id: Mapped[int] = mapped_column(
+        init=False, primary_key=True, autoincrement=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), default=None,
+    )
+
+    server_id: Mapped[int] = mapped_column(nullable=False, default=None, unique=True)
+
+    default_negative_prompt: Mapped[str] = mapped_column(default=None)
+    required_negative_prompt: Mapped[str] = mapped_column(default=None)
+
+    @classmethod
+    def get_server_preferences(cls, server_id:int) -> ServerPreferences:
+        with db_session() as session:
+            saved_preferences = session.scalar(select(ServerPreferences).where(ServerPreferences.server_id == server_id))
+            if saved_preferences is None:
+                saved_preferences = ServerPreferences(server_id=server_id)
+                session.add(saved_preferences)
+                session.commit()
+            
+            return saved_preferences
+
 
 class Generation(Base):
     __tablename__ = "generation"

--- a/stabby/schema.py
+++ b/stabby/schema.py
@@ -76,8 +76,8 @@ class ServerPreferences(Base):
 
     server_id: Mapped[int] = mapped_column(nullable=False, default=None, unique=True)
 
-    default_negative_prompt: Mapped[str] = mapped_column(default=None)
-    required_negative_prompt: Mapped[str] = mapped_column(default=None)
+    default_negative_prompt: Mapped[str] = mapped_column(default=None, nullable=True)
+    required_negative_prompt: Mapped[str] = mapped_column(default=None, nullable=True)
 
     @classmethod
     def get_server_preferences(cls, server_id:int) -> ServerPreferences:


### PR DESCRIPTION
Servers may have different permissiveness with prompts and may want to keep people from going too far into uncomfortable territory accidentally. Then again, some people may want all NSFW all the time. Something like this helps server owners cater to their crowd.

<img width="636" alt="Screen Shot 2024-06-16 at 2 28 26 PM" src="https://github.com/ricecake/stabby-disco-bot/assets/3711645/2e719bf4-1ddf-4513-835a-b7b88a0290dd">
<img width="696" alt="Screen Shot 2024-06-16 at 2 28 48 PM" src="https://github.com/ricecake/stabby-disco-bot/assets/3711645/45c4c8fb-511c-4b3d-8ebb-2e2f2eff2b0a">
<img width="572" alt="Screen Shot 2024-06-16 at 2 30 56 PM" src="https://github.com/ricecake/stabby-disco-bot/assets/3711645/d052d3f5-0676-4807-b964-0d3bd40faf75">
<img width="425" alt="Screen Shot 2024-06-16 at 2 31 09 PM" src="https://github.com/ricecake/stabby-disco-bot/assets/3711645/12cbd87c-a87d-40ab-bf24-f01a37e84176">
<img width="609" alt="Screen Shot 2024-06-16 at 2 31 28 PM" src="https://github.com/ricecake/stabby-disco-bot/assets/3711645/20a51377-eb38-46f0-afeb-16e9e7dbf873">
<img width="304" alt="Screen Shot 2024-06-16 at 2 31 44 PM" src="https://github.com/ricecake/stabby-disco-bot/assets/3711645/895e1985-b5b3-4c0c-a8d7-ac6c0dd94b6c">
